### PR TITLE
Use go from an archive instead of building from source.

### DIFF
--- a/vm-go.sh
+++ b/vm-go.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
 
+GO_VERSION="1.2.2"
+GO_ARCHIVE="go${GO_VERSION}.linux-amd64.tar.gz"
+
 apt-get update
 apt-get install -y build-essential git-core mercurial
 cd /opt
-hg clone -u release https://code.google.com/p/go
-cd go/src
-./all.bash
+wget -q "https://storage.googleapis.com/golang/$GO_ARCHIVE"
+tar -xzf "$GO_ARCHIVE"
 
 cat > /home/vagrant/.profile <<EOF
+export GOROOT=/opt/go
 export GOPATH=\$HOME
-export PATH=\$HOME/bin:/opt/go/bin:\$PATH
+export PATH=\$HOME/bin:\$GOROOT/bin:\$PATH
 export ZOOKEEPER_SERVERS=192.168.12.11:2181,192.168.12.12:2181,192.168.12.13:2181
 EOF
 chown vagrant:vagrant /home/vagrant/.profile


### PR DESCRIPTION
Not sure if there was a reason for pulling from source control and compiling but this makes the go VM come up much quicker.
